### PR TITLE
[Feature] Get page info from background script

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "@testing-library/jest-dom": "^5.14.1",
     "@testing-library/react": "^11.2.7",
     "@testing-library/user-event": "^12.8.3",
+    "lodash": "^4.17.21",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "react-hot-loader": "^4.13.0",

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -6,18 +6,15 @@
   "homepage_url": "https://github.com/shinenic/github-review-enhancer",
   "author": "",
   "minimum_chrome_version": "60",
-  "permissions": [
-    "storage"
-  ],
+  "permissions": ["storage", "webNavigation"],
+  "background": {
+    "service_worker": "background.js"
+  },
   "content_scripts": [
     {
       "run_at": "document_idle",
-      "matches": [
-        "https://github.com/*"
-      ],
-      "js": [
-        "content.js"
-      ]
+      "matches": ["https://github.com/*"],
+      "js": ["content.js"]
     }
   ]
 }

--- a/src/App.js
+++ b/src/App.js
@@ -1,4 +1,9 @@
+import usePageInfo from 'hooks/usePageInfo'
+
 function App() {
+  const pageInfo = usePageInfo()
+  console.log({ ...pageInfo })
+
   return <div />
 }
 

--- a/src/background.js
+++ b/src/background.js
@@ -1,0 +1,26 @@
+import { GLOBAL_MESSAGE_TYPE } from 'constants'
+
+const activeTabUrlMemo = {}
+
+/**
+ * To support Github SPA
+ * ref: https://developer.chrome.com/docs/extensions/reference/webNavigation/
+ */
+chrome.webNavigation.onHistoryStateUpdated.addListener(
+  ({ tabId, url }) => {
+    if (activeTabUrlMemo[tabId] !== url) {
+      activeTabUrlMemo[tabId] = url
+
+      chrome.tabs.sendMessage(tabId, {
+        type: GLOBAL_MESSAGE_TYPE.ON_HISTORY_UPDATED,
+      })
+    }
+  },
+  { url: [{ hostSuffix: 'github.com' }] }
+)
+
+chrome.tabs.onRemoved.addListener((tabId) => {
+  if (activeTabUrlMemo[tabId]) {
+    delete activeTabUrlMemo[tabId]
+  }
+})

--- a/src/constants/index.js
+++ b/src/constants/index.js
@@ -1,1 +1,5 @@
 export const CONTAINER_ID = 'github-review-enhancer'
+
+export const GLOBAL_MESSAGE_TYPE = {
+  ON_HISTORY_UPDATED: 'ON_HISTORY_UPDATED',
+}

--- a/src/constants/index.js
+++ b/src/constants/index.js
@@ -1,5 +1,13 @@
 export const CONTAINER_ID = 'github-review-enhancer'
 
+export const PAGE_TYPE = {
+  CODE: 'CODE',
+  PR: 'PR',
+  COMMIT: 'COMMIT',
+  PR_COMMIT: 'PR_COMMIT',
+  UNKNOWN: 'UNKNOWN',
+}
+
 export const GLOBAL_MESSAGE_TYPE = {
   ON_HISTORY_UPDATED: 'ON_HISTORY_UPDATED',
 }

--- a/src/hooks/useListenLocation.js
+++ b/src/hooks/useListenLocation.js
@@ -1,0 +1,22 @@
+import { useState, useEffect } from 'react'
+import { GLOBAL_MESSAGE_TYPE } from 'constants'
+
+const useListenLocation = () => {
+  const [currentLocation, setCurrentLocation] = useState({ ...location })
+
+  useEffect(() => {
+    const callback = (request) => {
+      if (request?.type === GLOBAL_MESSAGE_TYPE.ON_HISTORY_UPDATED) {
+        setCurrentLocation({ ...location })
+      }
+    }
+
+    chrome.runtime.onMessage.addListener(callback)
+
+    return () => chrome.runtime.onMessage.removeListener(callback)
+  }, [])
+
+  return currentLocation
+}
+
+export default useListenLocation

--- a/src/hooks/usePageInfo.js
+++ b/src/hooks/usePageInfo.js
@@ -1,0 +1,27 @@
+import { useState, useEffect } from 'react'
+import { PAGE_TYPE } from 'constants'
+import { getPageInfo } from 'utils/github'
+import useListenLocation from 'hooks/useListenLocation'
+
+const DEFAULT_PAGE_INFO = {
+  pageType: PAGE_TYPE.UNKNOWN,
+  owner: null,
+  repo: null,
+  commit: null,
+  pull: null,
+  branch: null,
+  filePath: null,
+}
+
+const usePageInfo = () => {
+  const [pageInfo, setPageInfo] = useState(DEFAULT_PAGE_INFO)
+  const { pathname } = useListenLocation()
+
+  useEffect(() => {
+    setPageInfo(getPageInfo(pathname, DEFAULT_PAGE_INFO))
+  }, [pathname])
+
+  return pageInfo
+}
+
+export default usePageInfo

--- a/src/utils/github.js
+++ b/src/utils/github.js
@@ -1,0 +1,76 @@
+import { PAGE_TYPE } from 'constants'
+import { isEmpty } from 'lodash'
+
+const { CODE, PR, COMMIT, PR_COMMIT } = PAGE_TYPE
+
+/**
+ * @returns {object}   pageInfo - contains the below information,
+ *                                field will be empty if the data can't be gotten from pathname
+ * @returns {string}   pageInfo.pageType - one of `PAGE_TYPE`
+ * @returns {string}   pageInfo.owner    - repository owner
+ * @returns {string}   pageInfo.repo     - repository name
+ * @returns {string}   pageInfo.commit   - commit hash
+ * @returns {string}   pageInfo.pull     - pull request's number
+ * @returns {string}   pageInfo.branch   - branch name
+ * @returns {string[]} pageInfo.filePath - file's path
+ */
+export const getPageInfo = (pathname = '', defaultInfo = {}) => {
+  const [_, owner, repo, decisivePath, ...restPaths] = pathname.split('/')
+  const basicInfo = { ...defaultInfo, owner, repo }
+
+  /**
+   * {user}/{repo}
+   * {user}/{repo}/tree/{branch}/{filePath}
+   * {user}/{repo}/blob/{branch}/{filePath}
+   */
+  if (isEmpty(decisivePath) || ['tree', 'blob'].includes(decisivePath)) {
+    return {
+      ...basicInfo,
+      pageType: CODE,
+      ...(!isEmpty(decisivePath) && {
+        branch: restPaths[0],
+        filePath: restPaths.slice(1),
+      }),
+    }
+  }
+
+  /**
+   * {user}/{repo}/pull/{pull}/commits/{commit}
+   */
+  if (
+    decisivePath === 'pull' &&
+    restPaths[1] === 'commits' &&
+    !isEmpty(restPaths[2])
+  ) {
+    return {
+      ...basicInfo,
+      pageType: PR_COMMIT,
+      commit: restPaths[2],
+      pull: restPaths[0],
+    }
+  }
+
+  /**
+   * {user}/{repo}/commit/{commit}
+   */
+  if (decisivePath === 'commit' && !isEmpty(restPaths[0])) {
+    return {
+      ...basicInfo,
+      pageType: COMMIT,
+      commit: restPaths[0],
+    }
+  }
+
+  /**
+   * {user}/{repo}/pull/{pull}/*
+   */
+  if (decisivePath === 'pull' && !isEmpty(restPaths[0])) {
+    return {
+      ...basicInfo,
+      pageType: PR,
+      commit: restPaths[0],
+    }
+  }
+
+  return basicInfo
+}

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -4,6 +4,7 @@ const CopyPlugin = require('copy-webpack-plugin')
 const config = {
   entry: {
     content: path.join(__dirname, 'src/index.js'),
+    background: path.join(__dirname, 'src/background.js'),
   },
   output: { path: path.join(__dirname, 'build'), filename: '[name].js' },
   module: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -7573,7 +7573,7 @@ lodash.uniq@^4.5.0:
   resolved "https://registry.yarnpkg.com/lodash.uniq/-/lodash.uniq-4.5.0.tgz#d0225373aeb652adc1bc82e4945339a842754773"
   integrity sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=
 
-"lodash@>=3.5 <5", lodash@^4.17.11, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.20, lodash@^4.17.5:
+"lodash@>=3.5 <5", lodash@^4.17.11, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.20, lodash@^4.17.21, lodash@^4.17.5:
   version "4.17.21"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==


### PR DESCRIPTION
## Description
1. Get `history change event` from background script
2. Parse `pathname` and get page info (branch, commit, filePath, owner, pageType, repo)

## How to test
On the Github page,
1. Check the page info shows in the console
2. Toggle URL change without refresh and check if the extension logs

## Result
- In the pull request page
![image](https://user-images.githubusercontent.com/20126676/125420098-3105581a-66d3-426c-8cab-1b9542ea8247.png)

- In the commit page
![image](https://user-images.githubusercontent.com/20126676/125420291-c55f3695-95a6-4118-83ad-55d46fa03c30.png)

