### PR TITLE
feat: add common link for github page

### DIFF
--- a/src/components/shared/GithubLink.js
+++ b/src/components/shared/GithubLink.js
@@ -1,0 +1,51 @@
+import { PJAX_LINK_ID } from 'constants/github'
+
+const getHrefPathname = (href = '') => {
+  try {
+    const url = new URL(href)
+    return url.pathname
+  } catch {
+    const url = new URL(href, 'https://github.com')
+    return url.pathname
+  }
+}
+
+/**
+ * Component for navigation to Github page without refresh.
+ *
+ * @note These approach is based on `PJAX` attribute, but sometimes failed in some cases
+ *       e.g. user page <=> other pages
+ * @example
+ *   <GithubLink href="/user/repo/">repo index</GithubLink>
+ */
+const GithubLink = ({
+  href = '/',
+  disableSPA = false,
+  skipIfSamePathname = true,
+  onClick,
+  children,
+  ...rest
+}) => {
+  const handleClick = (e) => {
+    if (skipIfSamePathname && getHrefPathname(href) === location.pathname) {
+      e.preventDefault()
+    }
+
+    if (onClick) {
+      onClick(e)
+    }
+  }
+
+  return (
+    <a
+      href={href}
+      onClick={handleClick}
+      {...(!disableSPA && { 'data-pjax': PJAX_LINK_ID })}
+      {...rest}
+    >
+      {children}
+    </a>
+  )
+}
+
+export default GithubLink

--- a/src/constants/github.js
+++ b/src/constants/github.js
@@ -1,0 +1,1 @@
+export const PJAX_LINK_ID = '#repo-content-pjax-container'


### PR DESCRIPTION
## Description
Add common link for Github page

## Todo
Relocate shared component to another folder

## Known issue
Failed at these cases:
`User page <=> other pages`

## How to test
Test via the cases below
```javascript
      <GithubLink href="/shinenic/github-review-enhancer/blob/master/src/background.js">
        background.js
      </GithubLink>

      <GithubLink href="/shinenic">user index</GithubLink>

      <GithubLink href="/shinenic/github-review-enhancer/">
        repo index
      </GithubLink>

      <GithubLink href="/shinenic/github-review-enhancer/pull/2">
        pull 2
      </GithubLink>

      <GithubLink href="/shinenic/github-review-enhancer/pull/1">
        pull 1
      </GithubLink>
```