### PR TITLE
refactor: rename `pr` to `pull` and fix pageinfo error

### DIFF
--- a/src/constants/index.js
+++ b/src/constants/index.js
@@ -2,9 +2,9 @@ export const CONTAINER_ID = 'github-review-enhancer'
 
 export const PAGE_TYPE = {
   CODE: 'CODE',
-  PR: 'PR',
+  PULL: 'PULL',
   COMMIT: 'COMMIT',
-  PR_COMMIT: 'PR_COMMIT',
+  PULL_COMMIT: 'PULL_COMMIT',
   UNKNOWN: 'UNKNOWN',
 }
 

--- a/src/hooks/api/useGithubQueries.js
+++ b/src/hooks/api/useGithubQueries.js
@@ -8,10 +8,10 @@ export const useQueryRepoInfo = ({ owner, repo, ...rest }) => {
   })
 }
 
-export const useQueryCommits = ({ owner, repo, PR, ...rest }) => {
+export const useQueryCommits = ({ owner, repo, pull, ...rest }) => {
   return useGithubQuery({
-    url: '/repos/{owner}/{repo}/pulls/{PR}/commits',
-    placeholders: { owner, repo, PR },
+    url: '/repos/{owner}/{repo}/pulls/{pull}/commits',
+    placeholders: { owner, repo, pull },
     ...rest,
   })
 }
@@ -24,16 +24,16 @@ export const useQueryCommit = ({ owner, repo, commit, ...rest }) => {
   })
 }
 
-export const useQueryPR = ({ owner, repo, PR, perPage = 100, ...rest }) => {
+export const useQueryPull = ({ owner, repo, pull, perPage = 100, ...rest }) => {
   return useGithubQuery({
-    url: '/repos/{owner}/{repo}/pulls/{PR}/files',
-    placeholders: { owner, repo, PR },
+    url: '/repos/{owner}/{repo}/pulls/{pull}/files',
+    placeholders: { owner, repo, pull },
     params: { per_page: perPage },
     ...rest,
   })
 }
 
-export const useQueryPRs = ({
+export const useQueryPulls = ({
   owner,
   repo,
   perPage = 30,

--- a/src/utils/github.js
+++ b/src/utils/github.js
@@ -1,7 +1,7 @@
 import { PAGE_TYPE } from 'constants'
 import { isEmpty } from 'lodash'
 
-const { CODE, PR, COMMIT, PR_COMMIT } = PAGE_TYPE
+const { CODE, PULL, COMMIT, PULL_COMMIT } = PAGE_TYPE
 
 /**
  * @returns {object}   pageInfo - contains the below information,
@@ -44,7 +44,7 @@ export const getPageInfo = (pathname = '', defaultInfo = {}) => {
   ) {
     return {
       ...basicInfo,
-      pageType: PR_COMMIT,
+      pageType: PULL_COMMIT,
       commit: restPaths[2],
       pull: restPaths[0],
     }
@@ -67,7 +67,7 @@ export const getPageInfo = (pathname = '', defaultInfo = {}) => {
   if (decisivePath === 'pull' && !isEmpty(restPaths[0])) {
     return {
       ...basicInfo,
-      pageType: PR,
+      pageType: PULL,
       commit: restPaths[0],
     }
   }

--- a/src/utils/github.js
+++ b/src/utils/github.js
@@ -68,7 +68,7 @@ export const getPageInfo = (pathname = '', defaultInfo = {}) => {
     return {
       ...basicInfo,
       pageType: PULL,
-      commit: restPaths[0],
+      pull: restPaths[0],
     }
   }
 


### PR DESCRIPTION
## Description
- rename `pr` to `pull`
- fix pageinfo error