### PR TITLE
[Feature] Introduce react query

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "react-dom": "^17.0.2",
     "react-hot-loader": "^4.13.0",
     "react-icons": "^4.2.0",
+    "react-query": "^3.19.1",
     "react-router-dom": "^5.2.0",
     "react-scripts": "4.0.3",
     "react-spring": "^9.2.4",

--- a/src/App.js
+++ b/src/App.js
@@ -6,15 +6,15 @@ import usePageInfo from 'hooks/pageInfo/usePageInfo'
 const { UNKNOWN, UNSUPPORTED } = PAGE_TYPE
 
 function App() {
-  const { error, loading, pageInfo } = usePageInfo()
+  const { error, isLoading, pageInfo } = usePageInfo()
 
-  console.log({ error, loading, pageInfo })
+  console.log({ error, isLoading, pageInfo })
 
   if (
     pageInfo.pageType === UNKNOWN ||
     pageInfo.pageType === UNSUPPORTED ||
     error ||
-    loading
+    isLoading
   ) {
     return null
   }

--- a/src/components/MainDrawer/index.js
+++ b/src/components/MainDrawer/index.js
@@ -1,17 +1,14 @@
 import React from 'react'
-import PropTypes from 'prop-types'
 import Drawer from '@material-ui/core/Drawer'
-import CircularProgress from '@material-ui/core/CircularProgress'
 import { makeStyles } from '@material-ui/core/styles'
 import { PAGE_TYPE } from 'constants'
 
-import { useQueryRepoInfo } from 'hooks/api/useGithubQueries'
 import CodePage from 'components/pages/Code'
 import PullPage from 'components/pages/Pull'
 import PullCommit from 'components/pages/PullCommit'
 import PullCommitMenu from 'components/Menu/PullCommit'
 
-import { isEmpty, compact } from 'lodash'
+import { compact } from 'lodash'
 import * as Style from './style'
 
 const useStyles = makeStyles({
@@ -19,7 +16,6 @@ const useStyles = makeStyles({
     width: 400,
     display: 'flex',
     flexDirection: 'column',
-    // borderRightColor: 'black',
   },
 })
 
@@ -31,14 +27,9 @@ const MainDrawer = ({
   pull,
   branch: branchFromUrl,
   filePath,
+  defaultBranch,
 }) => {
   const classes = useStyles()
-
-  const { data, isLoading, error } = useQueryRepoInfo({ owner, repo })
-
-  if (isLoading || isEmpty(data) || error) return null
-
-  const { default_branch: defaultBranch } = data
   const branch = branchFromUrl || defaultBranch
 
   const renderHeader = () => {

--- a/src/components/MainDrawer/index.js
+++ b/src/components/MainDrawer/index.js
@@ -34,9 +34,9 @@ const MainDrawer = ({
 }) => {
   const classes = useStyles()
 
-  const { data, loading, error } = useQueryRepoInfo({ owner, repo })
+  const { data, isLoading, error } = useQueryRepoInfo({ owner, repo })
 
-  if (loading || isEmpty(data)) return null
+  if (isLoading || isEmpty(data) || error) return null
 
   const { default_branch: defaultBranch } = data
   const branch = branchFromUrl || defaultBranch

--- a/src/components/pages/Code/index.js
+++ b/src/components/pages/Code/index.js
@@ -4,9 +4,9 @@ import Tree from 'components/Tree'
 import { linkGithubPage, getFileLink } from 'utils/link'
 
 const Code = ({ owner, branch, repo }) => {
-  const { data, loading } = useQueryFiles({ owner, branch, repo })
+  const { data, isLoading } = useQueryFiles({ owner, branch, repo })
 
-  if (loading) return null
+  if (isLoading) return null
 
   const onItemClick = ({ path, type }) => {
     if (type === 'tree') return

--- a/src/components/pages/Pull/index.js
+++ b/src/components/pages/Pull/index.js
@@ -3,9 +3,9 @@ import { useQueryPull } from 'hooks/api/useGithubQueries'
 import Tree from 'components/Tree'
 
 const Pull = ({ owner, pull, repo }) => {
-  const { data, loading } = useQueryPull({ owner, pull, repo })
+  const { data, isLoading } = useQueryPull({ owner, pull, repo })
 
-  if (loading) return null
+  if (isLoading) return null
 
   return <Tree tree={data} repo={repo} isExpandedAll />
 }

--- a/src/components/pages/PullCommit/index.js
+++ b/src/components/pages/PullCommit/index.js
@@ -3,9 +3,9 @@ import { useQueryCommit } from 'hooks/api/useGithubQueries'
 import Tree from 'components/Tree'
 
 const PullCommit = ({ owner, commit, repo }) => {
-  const { data, loading, error } = useQueryCommit({ owner, commit, repo })
+  const { data, isLoading, error } = useQueryCommit({ owner, commit, repo })
 
-  if (loading || error) return null
+  if (isLoading || error) return null
 
   return <Tree tree={data.files} repo={repo} isExpandedAll />
 }

--- a/src/constants/index.js
+++ b/src/constants/index.js
@@ -23,4 +23,5 @@ export const DEFAULT_PAGE_INFO = {
   pull: null,
   branch: null,
   filePath: null,
+  defaultBranch: null,
 }

--- a/src/hooks/api/useGithubQueries.js
+++ b/src/hooks/api/useGithubQueries.js
@@ -1,65 +1,107 @@
 import useGithubQuery from './useGithubQuery'
 
-export const useQueryRepoInfo = ({ owner, repo, ...rest }) => {
-  return useGithubQuery({
-    url: '/repos/{owner}/{repo}',
-    placeholders: { owner, repo },
-    ...rest,
-  })
-}
-
-export const useQueryCommits = ({ owner, repo, pull, ...rest }) => {
-  return useGithubQuery({
-    url: '/repos/{owner}/{repo}/pulls/{pull}/commits',
-    placeholders: { owner, repo, pull },
-    ...rest,
-  })
-}
-
-export const useQueryCommit = ({ owner, repo, commit, ...rest }) => {
-  return useGithubQuery({
-    url: '/repos/{owner}/{repo}/commits/{commit}',
-    placeholders: { owner, repo, commit },
-    ...rest,
-  })
-}
-
-export const useQueryPull = ({ owner, repo, pull, perPage = 100, ...rest }) => {
-  return useGithubQuery({
-    url: '/repos/{owner}/{repo}/pulls/{pull}/files',
-    placeholders: { owner, repo, pull },
-    params: { per_page: perPage },
-    ...rest,
-  })
-}
-
-export const useQueryPulls = ({
-  owner,
-  repo,
-  perPage = 30,
-  sort = 'created',
-  direction = 'desc',
-  state = 'open',
-  ...rest
-}) => {
-  return useGithubQuery({
-    url: '/repos/{owner}/{repo}/pulls',
-    placeholders: { owner, repo },
-    params: {
-      sort: 'created',
-      direction: 'desc',
-      state: 'open',
-      per_page: perPage,
+export const useQueryRepoInfo = (
+  { owner, repo, ...rest },
+  useQueryOptions = {}
+) => {
+  return useGithubQuery(
+    ['repoInfo', { owner, repo }],
+    {
+      url: '/repos/{owner}/{repo}',
+      placeholders: { owner, repo },
+      ...rest,
     },
-    ...rest,
-  })
+    useQueryOptions
+  )
 }
 
-export const useQueryFiles = ({ owner, repo, branch, ...rest }) => {
-  return useGithubQuery({
-    url: '/repos/{owner}/{repo}/git/trees/{branch}',
-    placeholders: { owner, repo, branch },
-    params: { recursive: 1 },
-    ...rest,
-  })
+export const useQueryCommits = (
+  { owner, repo, pull, ...rest },
+  useQueryOptions = {}
+) => {
+  return useGithubQuery(
+    ['commits', { owner, repo, pull }],
+    {
+      url: '/repos/{owner}/{repo}/pulls/{pull}/commits',
+      placeholders: { owner, repo, pull },
+      ...rest,
+    },
+    useQueryOptions
+  )
+}
+
+export const useQueryCommit = (
+  { owner, repo, commit, ...rest },
+  useQueryOptions = {}
+) => {
+  return useGithubQuery(
+    ['commit', { owner, repo, commit }],
+    {
+      url: '/repos/{owner}/{repo}/commits/{commit}',
+      placeholders: { owner, repo, commit },
+      ...rest,
+    },
+    useQueryOptions
+  )
+}
+
+export const useQueryPull = (
+  { owner, repo, pull, perPage = 100, ...rest },
+  useQueryOptions = {}
+) => {
+  return useGithubQuery(
+    ['pull', { owner, repo, pull, perPage }],
+    {
+      url: '/repos/{owner}/{repo}/pulls/{pull}/files',
+      placeholders: { owner, repo, pull },
+      params: { per_page: perPage },
+      ...rest,
+    },
+    useQueryOptions
+  )
+}
+
+export const useQueryPulls = (
+  {
+    owner,
+    repo,
+    perPage = 30,
+    sort = 'created',
+    direction = 'desc',
+    state = 'open',
+    ...rest
+  },
+  useQueryOptions = {}
+) => {
+  return useGithubQuery(
+    ['pulls', { owner, repo, perPage, sort, direction, state }],
+    {
+      url: '/repos/{owner}/{repo}/pulls',
+      placeholders: { owner, repo },
+      params: {
+        sort: 'created',
+        direction: 'desc',
+        state: 'open',
+        per_page: perPage,
+      },
+      ...rest,
+    },
+    useQueryOptions
+  )
+}
+
+export const useQueryFiles = (
+  { owner, repo, branch, ...rest },
+  useQueryOptions = {}
+) => {
+  return useGithubQuery(
+    ['files', { owner, repo, branch }],
+    {
+      url: '/repos/{owner}/{repo}/git/trees/{branch}',
+      placeholders: { owner, repo, branch },
+      params: { recursive: 1 },
+      ...rest,
+    },
+    useQueryOptions
+  )
 }

--- a/src/hooks/api/useGithubQuery.js
+++ b/src/hooks/api/useGithubQuery.js
@@ -13,6 +13,7 @@ function useGithubQuery(queryKeys, variables = {}, useQueryOptions = {}) {
     },
     {
       enabled: enabled && isValidQuery(url, placeholders),
+      refetchOnWindowFocus: false,
       ...useQueryOptions,
     }
   )

--- a/src/hooks/api/useGithubQuery.js
+++ b/src/hooks/api/useGithubQuery.js
@@ -1,90 +1,21 @@
-import { useState, useCallback } from 'react'
-import useDeepCompareEffect from 'use-deep-compare-effect'
+import { useQuery } from 'react-query'
+import { isValidQuery, createGithubQuery } from 'utils/api'
 
-import { request } from '@octokit/request'
+function useGithubQuery(queryKeys, variables = {}, useQueryOptions = {}) {
+  const { url, placeholders = {}, token } = variables
+  const { enabled = true } = useQueryOptions
 
-export const isValidQuery = (url, placeholders) => {
-  if (!url || url.length === 0) return false
-  const urlKeys = url.match(/{\w+}/g).map((str) => str.slice(1, -1))
-
-  return urlKeys.every((key) => placeholders[key])
-}
-
-/**
- * @example - get commits from one pull request
- * https://api.github.com/repos/microsoft/fluentui/pulls/18787/commits?page=2
- *
- * const { data, error, loading } = useGithubQuery({
- *   url: '/repos/{owner}/{repo}/pulls/{pull_number}/commits'
- *   placeholders: {
- *     owner: 'microsoft',
- *     repo: 'fluentui',
- *     pull_number: '18787'
- *   },
- *   params: { page: 2 },
- * })
- */
-const useGithubQuery = ({
-  url,
-  token,
-  placeholders = {},
-  params = {},
-  options = {},
-  method = 'GET',
-  enabled = true,
-} = {}) => {
-  const [data, setData] = useState(null)
-  const [error, setError] = useState(null)
-  const [loading, setLoading] = useState(
-    () => url && enabled && isValidQuery(url, placeholders)
-  )
-
-  const resetStates = useCallback(() => {
-    setLoading(true)
-    setError(null)
-    setData(null)
-  }, [])
-
-  useDeepCompareEffect(() => {
-    if (!url || !enabled || !isValidQuery(url, placeholders)) return
-
-    const abortCtrl = new AbortController()
-
-    const startQuery = async () => {
-      try {
-        const result = await request({
-          method,
-          url,
-          ...placeholders,
-          ...params,
-          ...options,
-          request: {
-            signal: abortCtrl.signal,
-          },
-          ...(token && {
-            headers: { authorization: `token ${token}` },
-          }),
-        })
-
-        if (result?.data?.message) {
-          setError(result?.data?.message)
-        } else {
-          setData(result?.data)
-        }
-      } catch (error) {
-        setError(error)
-      } finally {
-        setLoading(false)
-      }
+  return useQuery(
+    [...queryKeys, { token }],
+    async () => {
+      const { data } = await createGithubQuery(variables)
+      return data
+    },
+    {
+      enabled: enabled && isValidQuery(url, placeholders),
+      ...useQueryOptions,
     }
-
-    resetStates()
-    startQuery()
-
-    return () => abortCtrl.abort()
-  }, [url, token, placeholders, params, options, method, enabled])
-
-  return { data, loading, error }
+  )
 }
 
 export default useGithubQuery

--- a/src/hooks/pageInfo/usePageInfo.js
+++ b/src/hooks/pageInfo/usePageInfo.js
@@ -15,7 +15,7 @@ import useListenTitle from 'hooks/pageInfo/useListenTitle'
  * 3. title    - from dom listener
  * @typedef {Object} PageInfoHook
  * @property {PageInfo} pageInfo
- * @property {boolean} loading
+ * @property {boolean} isLoading
  * @property {boolean} error
  *
  * @returns {PageInfoHook}
@@ -24,7 +24,7 @@ const usePageInfo = () => {
   const { pathname } = useListenLocation()
   const title = useListenTitle()
   const [_, firstPath, secondPath] = pathname.split('/')
-  const { data, loading, error } = useQueryRepoInfo({
+  const { data, isLoading, error } = useQueryRepoInfo({
     owner: firstPath,
     repo: secondPath,
   })
@@ -38,13 +38,13 @@ const usePageInfo = () => {
     }
   }, [pathname, validRepoId, title])
 
-  if (loading) return { error: false, loading: true, pageInfo: {} }
+  if (isLoading) return { error: null, isLoading: true, pageInfo: {} }
 
   if (!validRepoId || error) {
-    return { error: true, loading: false, pageInfo: {} }
+    return { error, isLoading: false, pageInfo: {} }
   }
 
-  return { error: false, loading: false, pageInfo }
+  return { error: null, isLoading: false, pageInfo }
 }
 
 export default usePageInfo

--- a/src/hooks/pageInfo/usePageInfo.js
+++ b/src/hooks/pageInfo/usePageInfo.js
@@ -24,23 +24,29 @@ const usePageInfo = () => {
   const { pathname } = useListenLocation()
   const title = useListenTitle()
   const [_, firstPath, secondPath] = pathname.split('/')
-  const { data, isLoading, error } = useQueryRepoInfo({
-    owner: firstPath,
-    repo: secondPath,
-  })
+  const { data, isLoading, error } = useQueryRepoInfo(
+    {
+      owner: firstPath,
+      repo: secondPath,
+    },
+    {
+      onSuccess: (data) => {
+        setPageInfo(getPageInfo(pathname, data?.default_branch, title))
+      },
+    }
+  )
   const [pageInfo, setPageInfo] = useState(() => getPageInfo(pathname))
 
-  const validRepoId = data?.id
-
+  // This effect handle SPA by listening `pathname`, `data` is used to get default branch only
   useEffect(() => {
-    if (validRepoId && title) {
+    if (data) {
       setPageInfo(getPageInfo(pathname, data?.default_branch, title))
     }
-  }, [pathname, validRepoId, title])
+  }, [pathname])
 
   if (isLoading) return { error: null, isLoading: true, pageInfo: {} }
 
-  if (!validRepoId || error) {
+  if (!data?.id || error) {
     return { error, isLoading: false, pageInfo: {} }
   }
 

--- a/src/hooks/usePullCommitMenu.js
+++ b/src/hooks/usePullCommitMenu.js
@@ -22,7 +22,7 @@ const usePullCommitMenu = ({ owner, repo, pull, commit }) => {
     reset: true,
   })
 
-  const { data, loading, error } = useQueryCommits({
+  const { data, isLoading, error } = useQueryCommits({
     owner,
     repo,
     pull,
@@ -47,7 +47,7 @@ const usePullCommitMenu = ({ owner, repo, pull, commit }) => {
   }, [commit, hasData])
 
   const handleButtonClick = () => {
-    if (loading) return
+    if (isLoading) return
 
     setMenuOpened((prev) => !prev)
   }
@@ -64,8 +64,8 @@ const usePullCommitMenu = ({ owner, repo, pull, commit }) => {
 
   return {
     data,
-    loading,
-    disabled: error || loading,
+    isLoading,
+    disabled: error || isLoading,
     handleClose,
     handleButtonClick,
     buttonText,

--- a/src/index.js
+++ b/src/index.js
@@ -2,6 +2,9 @@ import React from 'react'
 import ReactDOM from 'react-dom'
 import App from './App'
 import { CONTAINER_ID } from 'constants'
+import { QueryClient, QueryClientProvider } from 'react-query'
+
+const queryClient = new QueryClient()
 
 const createContainer = () => {
   const container = document.createElement('div')
@@ -13,7 +16,9 @@ createContainer()
 
 ReactDOM.render(
   <React.StrictMode>
-    <App />
+    <QueryClientProvider client={queryClient}>
+      <App />
+    </QueryClientProvider>
   </React.StrictMode>,
   document.getElementById(CONTAINER_ID)
 )

--- a/src/utils/api.js
+++ b/src/utils/api.js
@@ -1,0 +1,51 @@
+import { request } from '@octokit/request'
+
+export const isValidQuery = (url, placeholders) => {
+  if (!url || url.length === 0) return false
+  const urlKeys = url.match(/{\w+}/g).map((str) => str.slice(1, -1))
+
+  return urlKeys.every((key) => placeholders[key])
+}
+
+/**
+ * @example - get commits from one pull request
+ * https://api.github.com/repos/microsoft/fluentui/pulls/18787/commits?page=2
+ *
+ * const promise = createGithubQuery({
+ *   url: '/repos/{owner}/{repo}/pulls/{pull_number}/commits'
+ *   placeholders: {
+ *     owner: 'microsoft',
+ *     repo: 'fluentui',
+ *     pull_number: '18787'
+ *   },
+ *   params: { page: 2 },
+ * })
+ */
+export const createGithubQuery = ({
+  url,
+  token,
+  placeholders = {},
+  params = {},
+  options = {},
+  method = 'GET',
+} = {}) => {
+  const controller = new AbortController()
+
+  const promise = request({
+    method,
+    url,
+    ...placeholders,
+    ...params,
+    ...options,
+    request: {
+      signal: controller.signal,
+    },
+    ...(token && {
+      headers: { authorization: `token ${token}` },
+    }),
+  })
+
+  promise.cancel = () => controller.abort()
+
+  return promise
+}

--- a/src/utils/github.js
+++ b/src/utils/github.js
@@ -27,6 +27,7 @@ export const getPageInfo = (pathname = '', defaultBranch, title) => {
     repo: second,
     branch,
     pageType: UNKNOWN,
+    defaultBranch,
   }
 
   /**

--- a/yarn.lock
+++ b/yarn.lock
@@ -1336,6 +1336,13 @@
   dependencies:
     regenerator-runtime "^0.13.4"
 
+"@babel/runtime@^7.6.2":
+  version "7.14.8"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.14.8.tgz#7119a56f421018852694290b9f9148097391b446"
+  integrity sha512-twj3L8Og5SaCRCErB4x4ajbvBIVV77CGeFglHpeg5WC5FF8TZzBWXtTJ4MqaD9QszLYTtr+IsaAL2rEUevb+eg==
+  dependencies:
+    regenerator-runtime "^0.13.4"
+
 "@babel/template@^7.10.4", "@babel/template@^7.12.13", "@babel/template@^7.3.3":
   version "7.12.13"
   resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.12.13.tgz#530265be8a2589dbb37523844c5bcb55947fb327"
@@ -4140,6 +4147,11 @@ bfj@^7.0.2:
     hoopy "^0.1.4"
     tryer "^1.0.1"
 
+big-integer@^1.6.16:
+  version "1.6.48"
+  resolved "https://registry.yarnpkg.com/big-integer/-/big-integer-1.6.48.tgz#8fd88bd1632cba4a1c8c3e3d7159f08bb95b4b9e"
+  integrity sha512-j51egjPa7/i+RdiRuJbPdJ2FIUYYPhvYLjzoYbcMMm62ooO6F94fETG4MTs46zPAF9Brs04OajboA/qTGuz78w==
+
 big.js@^5.2.2:
   version "5.2.2"
   resolved "https://registry.yarnpkg.com/big.js/-/big.js-5.2.2.tgz#65f0af382f578bcdc742bd9c281e9cb2d7768328"
@@ -4240,6 +4252,20 @@ braces@^3.0.1, braces@~3.0.2:
   integrity sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==
   dependencies:
     fill-range "^7.0.1"
+
+broadcast-channel@^3.4.1:
+  version "3.7.0"
+  resolved "https://registry.yarnpkg.com/broadcast-channel/-/broadcast-channel-3.7.0.tgz#2dfa5c7b4289547ac3f6705f9c00af8723889937"
+  integrity sha512-cIAKJXAxGJceNZGTZSBzMxzyOn72cVgPnKx4dc6LRjQgbaJUQqhy5rzL3zbMxkMWsGKkv2hSFkPRMEXfoMZ2Mg==
+  dependencies:
+    "@babel/runtime" "^7.7.2"
+    detect-node "^2.1.0"
+    js-sha3 "0.8.0"
+    microseconds "0.2.0"
+    nano-time "1.0.0"
+    oblivious-set "1.0.0"
+    rimraf "3.0.2"
+    unload "2.2.0"
 
 brorand@^1.0.1, brorand@^1.1.0:
   version "1.1.0"
@@ -5562,6 +5588,11 @@ detect-node@^2.0.4:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/detect-node/-/detect-node-2.0.4.tgz#014ee8f8f669c5c58023da64b8179c083a28c46c"
   integrity sha512-ZIzRpLJrOj7jjP2miAtgqIfmzbxa4ZOr5jJc601zklsfEx9oTzmmj2nVpIPRpNlRTIh8lc1kyViIY7BWSGNmKw==
+
+detect-node@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/detect-node/-/detect-node-2.1.0.tgz#c9c70775a49c3d03bc2c06d9a73be550f978f8b1"
+  integrity sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g==
 
 detect-port-alt@1.1.6:
   version "1.1.6"
@@ -8373,6 +8404,11 @@ jest@26.6.0:
     import-local "^3.0.2"
     jest-cli "^26.6.0"
 
+js-sha3@0.8.0:
+  version "0.8.0"
+  resolved "https://registry.yarnpkg.com/js-sha3/-/js-sha3-0.8.0.tgz#b9b7a5da73afad7dedd0f8c463954cbde6818840"
+  integrity sha512-gF1cRrHhIzNfToc802P800N8PpXS+evLLXfsVpowqmAFR9uwbi89WvXg2QspOmXL8QL86J4T1EpFu+yUkwJY3Q==
+
 "js-tokens@^3.0.0 || ^4.0.0", js-tokens@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
@@ -8870,6 +8906,14 @@ map-visit@^1.0.0:
   dependencies:
     object-visit "^1.0.0"
 
+match-sorter@^6.0.2:
+  version "6.3.0"
+  resolved "https://registry.yarnpkg.com/match-sorter/-/match-sorter-6.3.0.tgz#454a1b31ed218cddbce6231a0ecb5fdc549fed01"
+  integrity sha512-efYOf/wUpNb8FgNY+cOD2EIJI1S5I7YPKsw0LBp7wqPh5pmMS6i/wr3ZWwfwrAw1NvqTA2KUReVRWDX84lUcOQ==
+  dependencies:
+    "@babel/runtime" "^7.12.5"
+    remove-accents "0.4.2"
+
 md5.js@^1.3.4:
   version "1.3.5"
   resolved "https://registry.yarnpkg.com/md5.js/-/md5.js-1.3.5.tgz#b5d07b8e3216e3e27cd728d72f70d1e6a342005f"
@@ -8969,6 +9013,11 @@ micromatch@^4.0.4:
   dependencies:
     braces "^3.0.1"
     picomatch "^2.2.3"
+
+microseconds@0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/microseconds/-/microseconds-0.2.0.tgz#233b25f50c62a65d861f978a4a4f8ec18797dc39"
+  integrity sha512-n7DHHMjR1avBbSpsTBj6fmMGh2AGrifVV4e+WYc3Q9lO+xnSZ3NyhcBND3vzzatt05LFhoKFRxrIyklmLlUtyA==
 
 miller-rabin@^4.0.0:
   version "4.0.1"
@@ -9178,6 +9227,13 @@ nan@^2.12.1:
   version "2.14.2"
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.14.2.tgz#f5376400695168f4cc694ac9393d0c9585eeea19"
   integrity sha512-M2ufzIiINKCuDfBSAUr1vWQ+vuVcA9kqx8JJUsbQi6yf1uGRyb7HfpdfUr5qLXf3B/t8dPvcjhKMmlfnP47EzQ==
+
+nano-time@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/nano-time/-/nano-time-1.0.0.tgz#b0554f69ad89e22d0907f7a12b0993a5d96137ef"
+  integrity sha1-sFVPaa2J4i0JB/ehKwmTpdlhN+8=
+  dependencies:
+    big-integer "^1.6.16"
 
 nanoid@^3.1.20:
   version "3.1.20"
@@ -9484,6 +9540,11 @@ object.values@^1.1.0, object.values@^1.1.1:
     define-properties "^1.1.3"
     es-abstract "^1.18.0-next.1"
     has "^1.0.3"
+
+oblivious-set@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/oblivious-set/-/oblivious-set-1.0.0.tgz#c8316f2c2fb6ff7b11b6158db3234c49f733c566"
+  integrity sha512-z+pI07qxo4c2CulUHCDf9lcqDlMSo72N/4rLUpRXf6fu+q8vjt8y0xS+Tlf8NTJDdTXHbdeO1n3MlbctwEoXZw==
 
 obuf@^1.0.0, obuf@^1.1.2:
   version "1.1.2"
@@ -10966,6 +11027,15 @@ react-lifecycles-compat@^3.0.4:
   resolved "https://registry.yarnpkg.com/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz#4f1a273afdfc8f3488a8c516bfda78f872352362"
   integrity sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA==
 
+react-query@^3.19.1:
+  version "3.19.1"
+  resolved "https://registry.yarnpkg.com/react-query/-/react-query-3.19.1.tgz#f3fbd5af48b6c47901ab230f7c028c6f845254ac"
+  integrity sha512-tMBVKlmWevPHYWgI8ZBEgsTulJXSuXsxDbxqANODRnPI+3hd5GRVcc7nNIYSUx3aaULt08rN3EhTMHyTcFUNJw==
+  dependencies:
+    "@babel/runtime" "^7.5.5"
+    broadcast-channel "^3.4.1"
+    match-sorter "^6.0.2"
+
 react-refresh@^0.8.3:
   version "0.8.3"
   resolved "https://registry.yarnpkg.com/react-refresh/-/react-refresh-0.8.3.tgz#721d4657672d400c5e3c75d063c4a85fb2d5d68f"
@@ -11304,6 +11374,11 @@ relateurl@^0.2.7:
   resolved "https://registry.yarnpkg.com/relateurl/-/relateurl-0.2.7.tgz#54dbf377e51440aca90a4cd274600d3ff2d888a9"
   integrity sha1-VNvzd+UUQKypCkzSdGANP/LYiKk=
 
+remove-accents@0.4.2:
+  version "0.4.2"
+  resolved "https://registry.yarnpkg.com/remove-accents/-/remove-accents-0.4.2.tgz#0a43d3aaae1e80db919e07ae254b285d9e1c7bb5"
+  integrity sha1-CkPTqq4egNuRngeuJUsoXZ4ce7U=
+
 remove-trailing-separator@^1.0.1:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz#c24bce2a283adad5bc3f58e0d48249b92379d8ef"
@@ -11501,17 +11576,17 @@ rgba-regex@^1.0.0:
   resolved "https://registry.yarnpkg.com/rgba-regex/-/rgba-regex-1.0.0.tgz#43374e2e2ca0968b0ef1523460b7d730ff22eeb3"
   integrity sha1-QzdOLiyglosO8VI0YLfXMP8i7rM=
 
+rimraf@3.0.2, rimraf@^3.0.0, rimraf@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-3.0.2.tgz#f1a5402ba6220ad52cc1282bac1ae3aa49fd061a"
+  integrity sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==
+  dependencies:
+    glob "^7.1.3"
+
 rimraf@^2.5.4, rimraf@^2.6.3:
   version "2.7.1"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.7.1.tgz#35797f13a7fdadc566142c29d4f07ccad483e3ec"
   integrity sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==
-  dependencies:
-    glob "^7.1.3"
-
-rimraf@^3.0.0, rimraf@^3.0.2:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-3.0.2.tgz#f1a5402ba6220ad52cc1282bac1ae3aa49fd061a"
-  integrity sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==
   dependencies:
     glob "^7.1.3"
 
@@ -12904,6 +12979,14 @@ universalify@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/universalify/-/universalify-2.0.0.tgz#75a4984efedc4b08975c5aeb73f530d02df25717"
   integrity sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==
+
+unload@2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/unload/-/unload-2.2.0.tgz#ccc88fdcad345faa06a92039ec0f80b488880ef7"
+  integrity sha512-B60uB5TNBLtN6/LsgAf3udH9saB5p7gqJwcFfbOEZ8BcBHnGwCf6G/TGiEqkRAxX7zAFIUtzdrXQSdL3Q/wqNA==
+  dependencies:
+    "@babel/runtime" "^7.6.2"
+    detect-node "^2.0.4"
 
 unpipe@1.0.0, unpipe@~1.0.0:
   version "1.0.0"


### PR DESCRIPTION
## Summary

1. Add `react-query`
2. Migrate `octokit/request` and `react-query`
3. Remove duplicated query, `usePageInfo` will get the `defaultBranch` and put into `pageInfo` now, no need to query again.

## About `react-query`

### Main API
https://react-query.tanstack.com/reference/useQuery#_top

### Cache
https://react-query.tanstack.com/guides/query-keys
The cache will store the api data based on `Query Keys`, all of the following queries are considered equal:
```javascript
 useQuery(['repo', { owner, repo }], ...)
 useQuery(['repo', { repo, owner }], ...)
 useQuery(['repo', { owner, repo, other: undefined }], ...)
```